### PR TITLE
Fixed a deadlock when closing the audio device.

### DIFF
--- a/src/thread/pthread/SDL_syssem.c
+++ b/src/thread/pthread/SDL_syssem.c
@@ -101,6 +101,11 @@ SDL_SemWait(SDL_sem * sem)
     return retval;
 }
 
+#ifdef __ANDROID__
+// Android has this so... wtf?
+#define HAVE_SEM_TIMEDWAIT
+#endif
+
 int
 SDL_SemWaitTimeout(SDL_sem * sem, Uint32 timeout)
 {


### PR DESCRIPTION
The audio player thread was getting stuck waiting for a semaphore to be incremented
when the SDL_CloseAudioDevice function was called. The easiest fix was to switch to
a timed wait on the semaphore that would check if shutdown had been called if the
wait on the semaphore timed out.